### PR TITLE
Prevent terminal leak when closed from the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-evergreen",
   "displayName": "Angular Evergreen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "expertly-simple",
   "license": "ISC",
   "description": "Quickly compare latest and next releases of Angular to your project's version. Leverage helpers to upgrade your Angular CLI projects with ease.",

--- a/src/helpers/terminalManager.ts
+++ b/src/helpers/terminalManager.ts
@@ -3,6 +3,15 @@ import { Terminal, window } from 'vscode'
 export class TerminalManager {
   private terminal: Terminal
 
+  constructor() {
+    window.onDidCloseTerminal(t => {
+      if (t === this.terminal) {
+        this.terminal = undefined
+        this.terminal.dispose()
+      }
+    })
+  }
+
   getTerminal() {
     this.showTerminal()
     return this.terminal


### PR DESCRIPTION
# Feature/Change Description

The terminal does not show up when using an available command, if it has been closed manually from the UI previously. To reproduce:

1. Open the VSCode terminal
2. Close the terminal using the trash button
3. Run any of the available extension commands

# Developer Checklist

- [ ] Updated documentation or README.md
- [x] If create new release, bumped version number
- [x] Ran `npm run style:fix` for code style enforcement
- [x] Ran `npm run lint:fix` for linting
