### PR TITLE
fix: change the 'Check npm packages' command icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,8 +160,8 @@
         "title": "Check npm Updates",
         "category": "Npm Updates",
         "icon": {
-          "light": "/resources/light/clipboard.svg",
-          "dark": "/resources/dark/clipboard.svg"
+          "light": "/resources/light/continue.svg",
+          "dark": "/resources/dark/continue.svg"
         }
       },
       {


### PR DESCRIPTION
# Feature/Change Description
This PR changed the 'Check npm packages' command icon for consistency purposes.
Resolves #104.

# Developer Checklist
- [ ] Updated documentation or README.md
- [ ] If create new release, bumped version number
- [X] Ran npm run style:fix for code style enforcement
- [X] Ran npm run lint:fix for linting